### PR TITLE
All requests are now made honouring the verify_ssl flag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    et_ccd_client (0.1.14)
+    et_ccd_client (0.1.15)
       addressable (~> 2.6)
       mechanize (~> 2.7, >= 2.7.6)
       rest-client (~> 2.0, >= 2.0.2)

--- a/lib/et_ccd_client/client.rb
+++ b/lib/et_ccd_client/client.rb
@@ -26,7 +26,7 @@ module EtCcdClient
       logger.tagged('EtCcdClient::Client') do
         url = initiate_case_url(case_type_id)
         logger.debug("ET > Start case creation (#{url})")
-        resp = RestClient::Request.execute(method: :get, url: url, headers: { content_type: 'application/json', 'ServiceAuthorization' => "Bearer #{idam_client.service_token}", :authorization => "Bearer #{idam_client.user_token}", 'user-id' => idam_client.user_details['id'], 'user-roles' => idam_client.user_details['roles'].join(',')}, verify_ssl: config.verify_ssl)
+        resp = RestClient::Request.execute(method: :get, url: url, headers: { content_type: 'application/json', 'ServiceAuthorization' => "Bearer #{idam_client.service_token}", :authorization => "Bearer #{idam_client.user_token}", 'user-id' => idam_client.user_details['id'], 'user-roles' => idam_client.user_details['roles'].join(',') }, verify_ssl: config.verify_ssl)
         logger.debug "ET < Start case creation - #{resp.body}"
         JSON.parse(resp.body)
       rescue RestClient::Exception => e
@@ -44,7 +44,7 @@ module EtCcdClient
         tpl = Addressable::Template.new(config.create_case_url)
         url = tpl.expand(uid: idam_client.user_details['id'], jid: config.jurisdiction_id, ctid: case_type_id).to_s
         logger.debug("ET > Caseworker create case (#{url}) - #{data.to_json}")
-        resp = RestClient.post(url, data, content_type: 'application/json', 'ServiceAuthorization' => "Bearer #{idam_client.service_token}", :authorization => "Bearer #{idam_client.user_token}")
+        resp = RestClient::Request.execute(method: :post, url: url, payload: data, headers: { content_type: 'application/json', 'ServiceAuthorization' => "Bearer #{idam_client.service_token}", :authorization => "Bearer #{idam_client.user_token}" }, verify_ssl: config.verify_ssl)
         resp_body = resp.body
         logger.debug "ET < Case worker create case - #{resp_body}"
         JSON.parse(resp_body)
@@ -88,7 +88,7 @@ module EtCcdClient
 
     def initiate_case_url(case_type_id)
       tpl = Addressable::Template.new(config.initiate_case_url)
-      url = tpl.expand(uid: idam_client.user_details['id'], jid: config.jurisdiction_id, ctid: case_type_id, etid: config.initiate_claim_event_id).to_s
+      tpl.expand(uid: idam_client.user_details['id'], jid: config.jurisdiction_id, ctid: case_type_id, etid: config.initiate_claim_event_id).to_s
     end
 
     attr_accessor :idam_client, :config, :logger

--- a/lib/et_ccd_client/idam_client.rb
+++ b/lib/et_ccd_client/idam_client.rb
@@ -18,7 +18,7 @@ module EtCcdClient
       logger.tagged('EtCcdClient::IdamClient') do
         self.service_token = exchange_service_token
         self.user_token = exchange_sidam_user_token(username, password)
-        self.user_details = get_user_details
+        self.user_details = fetch_user_details
       end
     end
 
@@ -31,7 +31,7 @@ module EtCcdClient
       url = config.idam_service_token_exchange_url
       data = { microservice: config.microservice, oneTimePassword: otp }.to_json
       logger.debug("ET > Idam service token exchange (#{url}) - #{data}")
-      resp = RestClient.post(url, data, content_type: 'application/json')
+      resp = RestClient::Request.execute(method: :post, url: url, payload: data, headers: { content_type: 'application/json' }, verify_ssl: config.verify_ssl)
       resp.body.tap do |resp_body|
         logger.debug "ET < Idam service token exchange - #{resp_body}"
       end
@@ -46,7 +46,7 @@ module EtCcdClient
       JSON.parse(resp_body)['access_token']
     end
 
-    def get_user_details
+    def fetch_user_details
       url = config.user_details_url
       logger.debug("ET > Idam get user details (#{url})")
       resp = RestClient::Request.execute(method: :get, url: url, headers: { 'Accept' => 'application/json', 'Authorization' => user_token }, verify_ssl: config.verify_ssl)

--- a/lib/et_ccd_client/tidam_client.rb
+++ b/lib/et_ccd_client/tidam_client.rb
@@ -31,7 +31,7 @@ module EtCcdClient
       url = config.idam_service_token_exchange_url
       data = { microservice: config.microservice, oneTimePassword: otp }.to_json
       logger.debug("ET > Idam service token exchange (#{url}) - #{data}")
-      resp = RestClient.post(url, data, content_type: 'application/json')
+      resp = RestClient::Request.execute(method: :post, url: url, payload: data, headers: { content_type: 'application/json' }, verify_ssl: config.verify_ssl)
       resp.body.tap do |resp_body|
         logger.debug "ET < Idam service token exchange - #{resp_body}"
       end
@@ -40,7 +40,7 @@ module EtCcdClient
     def exchange_tidam_user_token(user_id, user_role)
       url = config.idam_user_token_exchange_url
       logger.debug("ET > Idam user token exchange (#{url}) - id: #{user_id} role: #{user_role}")
-      resp = RestClient.post(url, id: user_id, role: user_role)
+      resp = RestClient::Request.execute(method: :post, url: url, payload: { id: user_id, role: user_role }, verify_ssl: config.verify_ssl)
       resp.body.tap do |resp_body|
         logger.debug "ET < Idam user token exchange - #{resp_body}"
       end
@@ -48,8 +48,8 @@ module EtCcdClient
 
     def get_user_details(user_id, role)
       {
-          'id' => user_id,
-          'roles' => role.split(',').map(&:strip)
+        'id' => user_id,
+        'roles' => role.split(',').map(&:strip)
       }
     end
 

--- a/lib/et_ccd_client/ui_remote_config.rb
+++ b/lib/et_ccd_client/ui_remote_config.rb
@@ -13,7 +13,7 @@ module EtCcdClient
     private
 
     def initialize
-      dynamic_config = JSON.parse(RestClient.get(Config.instance.case_management_ui_config_url).body)
+      dynamic_config = JSON.parse(RestClient::Request.execute(method: :get, url: Config.instance.case_management_ui_config_url, verify_ssl: config.verify_ssl).body)
       dynamic_config.each_pair do |key, value|
         setter = :"#{key}="
         send(setter, value) if respond_to?(setter, true)

--- a/lib/et_ccd_client/version.rb
+++ b/lib/et_ccd_client/version.rb
@@ -1,3 +1,3 @@
 module EtCcdClient
-  VERSION = "0.1.14"
+  VERSION = "0.1.15".freeze
 end

--- a/spec/et_ccd_client/client_spec.rb
+++ b/spec/et_ccd_client/client_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 require 'et_ccd_client'
 RSpec.describe EtCcdClient::Client do
-  let(:mock_idam_client) { instance_spy(EtCcdClient::IdamClient, service_token: 'mockservicetoken', login: nil) }
+  subject(:client) { described_class.new(idam_client: mock_idam_client, config: mock_config) }
+
+  let(:mock_idam_client) { instance_spy(EtCcdClient::IdamClient, service_token: 'mockservicetoken', user_token: 'mockusertoken', user_details: { 'id' => 'mockuserid', 'roles' => ['mockrole1', 'mockrole2'] }, login: nil) }
   let(:mock_config) { instance_double(EtCcdClient::Config, mock_config_values) }
   let(:mock_config_values) do
     {
@@ -29,11 +31,10 @@ RSpec.describe EtCcdClient::Client do
       end
     end
   end
-  subject(:client) { described_class.new(idam_client: mock_idam_client, config: mock_config) }
   let(:default_response_headers) { { 'Content-Type' => 'application/json' } }
 
   describe "#login" do
-    context 'using sidam' do
+    context 'when using sidam' do
       it "delegates to the idam client with default values" do
         # Act - Call with no arguments
         client.login
@@ -58,25 +59,24 @@ RSpec.describe EtCcdClient::Client do
         expect(mock_idam_client).to have_received(:login).with(password: 'password')
       end
 
-
     end
 
-    context 'using tidam' do
+    context 'when using tidam' do
       let(:mock_config_values) do
         {
-            auth_base_url: 'http://auth.mock.com',
-            idam_base_url: 'http://idam.mock.com',
-            data_store_base_url: 'http://data.mock.com',
-            jurisdiction_id: 'mockjid',
-            microservice: 'mockmicroservice',
-            microservice_secret: 'nottellingyouitsasecret',
-            logger: mock_logger,
-            user_id: 51,
-            initiate_claim_event_id: 'mockinitiateevent',
-            initiate_case_url: 'http://data.mock.com/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/event-triggers/{etid}/token',
-            create_case_url: 'http://data.mock.com/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases',
-            use_sidam: false,
-            verify_ssl: false
+          auth_base_url: 'http://auth.mock.com',
+          idam_base_url: 'http://idam.mock.com',
+          data_store_base_url: 'http://data.mock.com',
+          jurisdiction_id: 'mockjid',
+          microservice: 'mockmicroservice',
+          microservice_secret: 'nottellingyouitsasecret',
+          logger: mock_logger,
+          user_id: 51,
+          initiate_claim_event_id: 'mockinitiateevent',
+          initiate_case_url: 'http://data.mock.com/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/event-triggers/{etid}/token',
+          create_case_url: 'http://data.mock.com/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases',
+          use_sidam: false,
+          verify_ssl: false
         }
       end
       let(:mock_idam_client) { instance_spy(EtCcdClient::TidamClient, service_token: 'mockservicetoken', login: nil) }
@@ -112,8 +112,8 @@ RSpec.describe EtCcdClient::Client do
   describe "#caseworker_start_case_creation" do
     it "performs the correct http request" do
       # Arrange - stub the url
-      stub = stub_request(:get, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token").
-        to_return(body: '{}', headers: default_response_headers, status: 200)
+      stub = stub_request(:get, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token").
+             to_return(body: '{}', headers: default_response_headers, status: 200)
 
       # Act - Call the method
       client.caseworker_start_case_creation(case_type_id: 'mycasetypeid')
@@ -124,7 +124,7 @@ RSpec.describe EtCcdClient::Client do
 
     it "returns the correct hash from the json" do
       # Arrange - stub the url
-      stub_request(:get, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token").
+      stub_request(:get, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token").
         to_return(body: '{"test":"value"}', headers: default_response_headers, status: 200)
 
       # Act - Call the method
@@ -136,7 +136,7 @@ RSpec.describe EtCcdClient::Client do
 
     it "uses a tagged logger" do
       # Arrange - stub the url
-      stub_request(:get, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token").
+      stub_request(:get, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token").
         to_return(body: '{"test":"value"}', headers: default_response_headers, status: 200)
 
       # Act - Call the method
@@ -148,8 +148,8 @@ RSpec.describe EtCcdClient::Client do
 
     it "logs the request" do
       # Arrange - stub the url
-      url = "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token"
-      stub_request(:get, "#{url}").
+      url = "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token"
+      stub_request(:get, url).
         to_return(body: '{"test":"value"}', headers: default_response_headers, status: 200)
 
       # Act - Call the method
@@ -162,7 +162,7 @@ RSpec.describe EtCcdClient::Client do
     it "logs the response" do
       # Arrange - stub the url
       resp_body = '{"test":"value"}'
-      stub_request(:get, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token").
+      stub_request(:get, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token").
         to_return(body: resp_body, headers: default_response_headers, status: 200)
 
       # Act - Call the method
@@ -175,23 +175,26 @@ RSpec.describe EtCcdClient::Client do
     it "logs the response under error conditions" do
       # Arrange - stub the url
       resp_body = '{"message": "Not found"}'
-      stub_request(:get, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token").
+      stub_request(:get, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/event-triggers/mockinitiateevent/token").
         to_return(body: resp_body, headers: default_response_headers, status: 404)
 
       # Act - Call the method
-      client.caseworker_start_case_creation(case_type_id: 'mycasetypeid') rescue RestClient::NotFound
+      action = -> { client.caseworker_start_case_creation(case_type_id: 'mycasetypeid') }
 
       # Assert
-      expect(mock_logger).to have_received(:debug).with("ET < Start case creation (ERROR) - #{resp_body}")
+      aggregate_failures "Both exception should be raised and log should be recorded" do
+        expect(action).to raise_exception(RestClient::NotFound)
+        expect(mock_logger).to have_received(:debug).with("ET < Start case creation (ERROR) - #{resp_body}")
+      end
     end
   end
 
   describe "#caseworker_case_create" do
     it "performs the correct http request" do
       # Arrange - stub the url
-      stub = stub_request(:post, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/cases").
-        with(headers: {"Content-Type": "application/x-www-form-urlencoded"}).
-        to_return(body: '{}', headers: default_response_headers, status: 200)
+      stub = stub_request(:post, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/cases").
+             with(headers: { "Content-Type": "application/x-www-form-urlencoded" }).
+             to_return(body: '{}', headers: default_response_headers, status: 200)
 
       # Act - Call the method
       client.caseworker_case_create({}, case_type_id: 'mycasetypeid')
@@ -202,7 +205,7 @@ RSpec.describe EtCcdClient::Client do
 
     it "returns the correct json" do
       # Arrange - stub the url
-      stub_request(:post, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/cases").
+      stub_request(:post, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/cases").
         to_return(body: '{"test":"value"}', headers: default_response_headers, status: 200)
 
       # Act - Call the method
@@ -214,7 +217,7 @@ RSpec.describe EtCcdClient::Client do
 
     it "uses a tagged logger" do
       # Arrange - stub the url
-      stub_request(:post, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/cases").
+      stub_request(:post, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/cases").
         to_return(body: '{}', headers: default_response_headers, status: 200)
 
       # Act - Call the method
@@ -226,12 +229,12 @@ RSpec.describe EtCcdClient::Client do
 
     it "logs the request" do
       # Arrange - stub the url
-      url = "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/cases"
+      url = "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/cases"
       stub_request(:post, url).
         to_return(body: '{}', headers: default_response_headers, status: 200)
 
       # Act - Call the method
-      client.caseworker_case_create({test: :data}, case_type_id: 'mycasetypeid')
+      client.caseworker_case_create({ test: :data }, case_type_id: 'mycasetypeid')
 
       # Assert
       expect(mock_logger).to have_received(:debug).with("ET > Caseworker create case (#{url}) - {\"test\":\"data\"}")
@@ -240,7 +243,7 @@ RSpec.describe EtCcdClient::Client do
     it "logs the response" do
       # Arrange - stub the url
       resp_body = '{"test":"value"}'
-      stub_request(:post, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/cases").
+      stub_request(:post, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/cases").
         to_return(body: resp_body, headers: default_response_headers, status: 200)
 
       # Act - Call the method
@@ -253,82 +256,90 @@ RSpec.describe EtCcdClient::Client do
     it "logs the response under error conditions" do
       # Arrange - stub the url
       resp_body = {
-          "exception": "uk.gov.hmcts.ccd.endpoint.exceptions.CaseValidationException",
-          "timestamp": "2019-06-23T17:13:07.282",
-          "status": 422,
-          "error": "Unprocessable Entity",
-          "message": "Case data validation failed",
-          "path": "/caseworkers/22/jurisdictions/EMPLOYMENT/case-types/EmpTrib_MVP_1.0_Manc/cases",
-          "details": {
-              "field_errors": [
-                  {
-                      "id": "claimantType.claimant_addressUK.PostCode",
-                      "message": "1065^&%$£@():?><*& exceed maximum length 14"
-                  }
-              ]
-          }
+        "exception": "uk.gov.hmcts.ccd.endpoint.exceptions.CaseValidationException",
+        "timestamp": "2019-06-23T17:13:07.282",
+        "status": 422,
+        "error": "Unprocessable Entity",
+        "message": "Case data validation failed",
+        "path": "/caseworkers/22/jurisdictions/EMPLOYMENT/case-types/EmpTrib_MVP_1.0_Manc/cases",
+        "details": {
+          "field_errors": [
+            {
+              "id": "claimantType.claimant_addressUK.PostCode",
+              "message": "1065^&%$£@():?><*& exceed maximum length 14"
+            }
+          ]
+        }
       }.to_json
-      stub_request(:post, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/cases").
+      stub_request(:post, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/cases").
         to_return(body: resp_body, headers: default_response_headers, status: 422)
 
       # Act - Call the method
-      client.caseworker_case_create({}, case_type_id: 'mycasetypeid') rescue EtCcdClient::Exceptions::UnprocessableEntity
+      action = -> { client.caseworker_case_create({}, case_type_id: 'mycasetypeid') }
 
       # Assert
-      expect(mock_logger).to have_received(:debug).with("ET < Case worker create case (ERROR) - #{resp_body}")
+      aggregate_failures "Both exception should be raised and log should be recorded" do
+        expect(action).to raise_exception(EtCcdClient::Exceptions::UnprocessableEntity)
+        expect(mock_logger).to have_received(:debug).with("ET < Case worker create case (ERROR) - #{resp_body}")
+      end
     end
 
     it "re raises the response with the response body available under error conditions with detailed message" do
       # Arrange - stub the url
       resp_body = {
-          "exception": "uk.gov.hmcts.ccd.endpoint.exceptions.CaseValidationException",
-          "timestamp": "2019-06-23T17:13:07.282",
-          "status": 422,
-          "error": "Unprocessable Entity",
-          "message": "Case data validation failed",
-          "path": "/caseworkers/22/jurisdictions/EMPLOYMENT/case-types/EmpTrib_MVP_1.0_Manc/cases",
-          "details": {
-              "field_errors": [
-                  {
-                      "id": "claimantType.claimant_addressUK.PostCode",
-                      "message": "1065^&%$£@():?><*& exceed maximum length 14"
-                  }
-              ]
-          }
+        "exception": "uk.gov.hmcts.ccd.endpoint.exceptions.CaseValidationException",
+        "timestamp": "2019-06-23T17:13:07.282",
+        "status": 422,
+        "error": "Unprocessable Entity",
+        "message": "Case data validation failed",
+        "path": "/caseworkers/22/jurisdictions/EMPLOYMENT/case-types/EmpTrib_MVP_1.0_Manc/cases",
+        "details": {
+          "field_errors": [
+            {
+              "id": "claimantType.claimant_addressUK.PostCode",
+              "message": "1065^&%$£@():?><*& exceed maximum length 14"
+            }
+          ]
+        }
       }.to_json
-      stub_request(:post, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/cases").
+      stub_request(:post, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/cases").
         to_return(body: resp_body, headers: default_response_headers, status: 422)
 
       # Act - Call the method
       case_create = -> { client.caseworker_case_create({}, case_type_id: 'mycasetypeid') }
-      expect(case_create).to raise_error(EtCcdClient::Exceptions::UnprocessableEntity) do |error|
-        expect(error.message).to include("claimantType.claimant_addressUK.PostCode => 1065^&%$£@():?><*& exceed maximum length 14")
-      end
 
       # Assert
-      expect(mock_logger).to have_received(:debug).with("ET < Case worker create case (ERROR) - #{resp_body}")
+      aggregate_failures "Both exception should be raised and log should be recorded" do
+        expect(case_create).to raise_error(EtCcdClient::Exceptions::UnprocessableEntity) do |error|
+          expect(error.message).to include("claimantType.claimant_addressUK.PostCode => 1065^&%$£@():?><*& exceed maximum length 14")
+        end
+        expect(mock_logger).to have_received(:debug).with("ET < Case worker create case (ERROR) - #{resp_body}")
+      end
     end
 
     it "re raises the response with the response body available under error conditions with standard message" do
       # Arrange - stub the url
       resp_body = "Unauthorized"
-      stub_request(:post, "http://data.mock.com/caseworkers/51/jurisdictions/mockjid/case-types/mycasetypeid/cases").
+      stub_request(:post, "http://data.mock.com/caseworkers/mockuserid/jurisdictions/mockjid/case-types/mycasetypeid/cases").
         to_return(body: resp_body, headers: default_response_headers, status: 401)
 
       # Act - Call the method
       case_create = -> { client.caseworker_case_create({}, case_type_id: 'mycasetypeid') }
-      expect(case_create).to raise_error(EtCcdClient::Exceptions::Base) do |error|
-        expect(error.message).to include("Unauthorized")
-      end
 
       # Assert
-      expect(mock_logger).to have_received(:debug).with("ET < Case worker create case (ERROR) - #{resp_body}")
+      aggregate_failures "Both exception should be raised and log should be recorded" do
+        expect(case_create).to raise_error(EtCcdClient::Exceptions::Base) do |error|
+          expect(error.message).to include("Unauthorized")
+        end
+        expect(mock_logger).to have_received(:debug).with("ET < Case worker create case (ERROR) - #{resp_body}")
+      end
     end
   end
 
   describe "#caseworker_search_by_reference" do
 
   end
+
   describe "#caseworker_search_latest_by_reference" do
 
   end


### PR DESCRIPTION
This PR changes all requests to honour the verify_ssl flag so the code can run against real environments such as ccd demo


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
